### PR TITLE
Add download all button to shared folder page

### DIFF
--- a/apps/web/app/shared/[token]/page.tsx
+++ b/apps/web/app/shared/[token]/page.tsx
@@ -54,25 +54,50 @@ export default function SharedPage({
   );
 
   const getDownloadUrl = trpc.shares.getDownloadUrl.useMutation();
+  const [isDownloadingAll, setIsDownloadingAll] = useState(false);
+
+  const downloadFile = async (fileId?: string) => {
+    const result = await getDownloadUrl.mutateAsync({
+      token,
+      fileId,
+      password: enteredPassword,
+    });
+    const response = await fetch(result.url);
+    if (!response.ok) throw new Error(`Download failed (${response.status})`);
+    const blob = await response.blob();
+    const blobUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = blobUrl;
+    a.download = result.filename;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(blobUrl), 100);
+  };
 
   const handleDownload = async (fileId?: string) => {
     try {
-      const result = await getDownloadUrl.mutateAsync({
-        token,
-        fileId,
-        password: enteredPassword,
-      });
-      const response = await fetch(result.url);
-      if (!response.ok) throw new Error(`Download failed (${response.status})`);
-      const blob = await response.blob();
-      const blobUrl = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = blobUrl;
-      a.download = result.filename;
-      a.click();
-      setTimeout(() => URL.revokeObjectURL(blobUrl), 100);
+      await downloadFile(fileId);
     } catch (err) {
       toast.error((err as Error).message);
+    }
+  };
+
+  const handleDownloadAll = async (files: { id: string }[]) => {
+    setIsDownloadingAll(true);
+    let failed = 0;
+    // Sequential: each file consumes one of the link's maxDownloads budget,
+    // and parallel blob clicks get throttled by the browser.
+    for (const file of files) {
+      try {
+        await downloadFile(file.id);
+      } catch {
+        failed++;
+      }
+    }
+    setIsDownloadingAll(false);
+    if (failed > 0) {
+      toast.error(
+        `${failed} of ${files.length} ${failed === 1 ? "file" : "files"} failed to download`,
+      );
     }
   };
 
@@ -230,6 +255,21 @@ export default function SharedPage({
                 </div>
               ))}
             </div>
+
+            {displayFiles && displayFiles.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                disabled={isDownloadingAll}
+                onClick={() => handleDownloadAll(displayFiles)}
+              >
+                <Download className="size-3.5" />
+                {isDownloadingAll
+                  ? "Downloading…"
+                  : `Download all (${displayFiles.length})`}
+              </Button>
+            )}
 
             {browseQuery.isLoading && isBrowsing ? (
               <div className="border rounded-sm p-6 text-center">


### PR DESCRIPTION
## Summary

Adds a **Download all (N)** button to the folder view of the shared link page (`/shared/[token]`).

It loops over the files currently displayed and reuses the existing `trpc.shares.getDownloadUrl` mutation for each. The existing `handleDownload` was refactored into a bare `downloadFile` helper so the single-file buttons and the bulk button share one code path.

## Behavior notes / review asks

Two judgment calls worth a look:

- **Not recursive.** The button downloads files in the *current* folder view only. Navigating into a subfolder gives a fresh "Download all" for that level. Recursion is easy to add, but one click silently pulling an entire tree seemed like the wrong default.
- **Counts N against `maxDownloads`.** Each file consumes one of the share link's download budget, since that's how `shares.getDownloadUrl` already counts. This is pre-existing behavior for the per-file buttons, but this button makes it much easier to hit the cap by accident.

Downloads run sequentially rather than in parallel — parallel blob clicks get throttled by the browser. Failures are tallied into a single toast rather than one per file.

## Not zipping (deliberate)

There's no zip capability anywhere in the repo — no `jszip`/`archiver` dependency, no bulk route — so a real zip means a new dependency plus a server route streaming from the storage abstraction. That was a bigger change than the request implied. If a single `.zip` is preferred, that's the natural follow-up, and it would also let the download count as one against `maxDownloads` instead of N.

## Testing

`tsc --noEmit` passes clean for the changed file. Not exercised in a running app — the download path is worth a manual click-through before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)